### PR TITLE
Update documentation to include draft model and FRSpec usage in Docke…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,18 @@ docker run --gpus all -p 8000:8000 cpmcu:cuda12.6-release \
 # 1. Download model on host
 huggingface-cli download openbmb/MiniCPM4-8B --local-dir /path/to/model
 
-# 2. Mount model directory and run
+#    Also download draft model & FRSpec for speculative decoding (optional)
+huggingface-cli download openbmb/MiniCPM4-8B-Eagle-FRSpec-QAT-cpmcu --local-dir /path/to/draft
+
+# 2. Mount directories and run
 docker run --rm --gpus all \
   -v /path/to/model:/workspace/model \
+  -v /path/to/draft:/workspace/draft \
   cpmcu:cuda12.6-release \
   bash -lc 'cd examples && python3 minicpm4/test_generate.py \
     --model-path /workspace/model \
+    --draft-model-path /workspace/draft \
+    --frspec-path /workspace/draft \
     --prompt-text "Hello" --num-generate 128 --use-stream false'
 ```
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -82,12 +82,18 @@ docker run --gpus all -p 8000:8000 cpmcu:cuda12.6-release \
 # 1. 在宿主机下载模型
 huggingface-cli download openbmb/MiniCPM4-8B --local-dir /path/to/model
 
+#    同时下载离线草稿模型与 FRSpec（用于开启投机采样，可选）
+huggingface-cli download openbmb/MiniCPM4-8B-Eagle-FRSpec-QAT-cpmcu --local-dir /path/to/draft
+
 # 2. 挂载模型目录运行
 docker run --rm --gpus all \
   -v /path/to/model:/workspace/model \
+  -v /path/to/draft:/workspace/draft \
   cpmcu:cuda12.6-release \
   bash -lc 'cd examples && python3 minicpm4/test_generate.py \
     --model-path /workspace/model \
+    --draft-model-path /workspace/draft \
+    --frspec-path /workspace/draft \
     --prompt-text "你好" --num-generate 128 --use-stream false'
 ```
 

--- a/doc/ch/docker_use.md
+++ b/doc/ch/docker_use.md
@@ -91,12 +91,18 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \
 # 使用hf下载模型
 huggingface-cli download openbmb/MiniCPM4-8B --local-dir /path/to/model
 
+# 同时下载草稿模型与 FRSpec（用于投机采样，建议离线准备）
+huggingface-cli download openbmb/MiniCPM4-8B-Eagle-FRSpec-QAT-cpmcu --local-dir /path/to/draft
+
 # 运行时挂载并使用本地路径
 docker run --rm --gpus all \
   -v /path/to/model:/workspace/model \
+  -v /path/to/draft:/workspace/draft \
   cpmcu:cuda12.6-release \
   bash -lc 'cd examples && python3 minicpm4/test_generate.py \
     --model-path /workspace/model \
+    --draft-model-path /workspace/draft \
+    --frspec-path /workspace/draft \
     --prompt-text "你好" --num-generate 128 --use-stream false'
 ```
 

--- a/doc/en/docker_use.md
+++ b/doc/en/docker_use.md
@@ -91,12 +91,18 @@ When the container cannot directly access Hugging Face or download speeds are sl
 # Download model using hf
 huggingface-cli download openbmb/MiniCPM4-8B --local-dir /path/to/model
 
+# Also download draft model & FRSpec (for speculative decoding, recommended to prepare offline)
+huggingface-cli download openbmb/MiniCPM4-8B-Eagle-FRSpec-QAT-cpmcu --local-dir /path/to/draft
+
 # Mount and use local path at runtime
 docker run --rm --gpus all \
   -v /path/to/model:/workspace/model \
+  -v /path/to/draft:/workspace/draft \
   cpmcu:cuda12.6-release \
   bash -lc 'cd examples && python3 minicpm4/test_generate.py \
     --model-path /workspace/model \
+    --draft-model-path /workspace/draft \
+    --frspec-path /workspace/draft \
     --prompt-text "Hello" --num-generate 128 --use-stream false'
 ```
 

--- a/docker/cuda12.6/dockerfile
+++ b/docker/cuda12.6/dockerfile
@@ -74,5 +74,8 @@ RUN echo "=== CPM.cu Compilation Configuration ===" && \
     pip install .
 
 
+# Reset working directory for runtime to avoid importing from source tree
+WORKDIR /workspace
+
 # Expose port (if running API server)
 EXPOSE 8000


### PR DESCRIPTION
…r instructions

- Added instructions for downloading the draft model and FRSpec for speculative decoding in README and documentation files.
- Updated Docker run commands to include paths for the draft model and FRSpec in both English and Chinese documentation.
- Ensured consistency across all relevant documentation files regarding model usage.