### PR TITLE
Highlight RTX 50 CUDA 12.8 quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ We provide pre-built Docker images that support out-of-the-box GPU inference env
 
 ### Quick Start
 
+If you are using an RTX 50 series GPU, prefer the CUDA 12.8 image below. The repo's Docker docs already recommend CUDA 12.8 for RTX 50 series support.
+
 ```bash
 # Pull pre-built image
 docker pull modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.6:v1.0.0
@@ -87,6 +89,15 @@ docker run --gpus all -it cpmcu:cuda12.6-release /bin/bash
 # Start API server(need to login to huggingface or -v mount model)
 docker run --gpus all -p 8000:8000 cpmcu:cuda12.6-release \
   python examples/minicpm4/start_server.py --apply-sparse 
+```
+
+```bash
+# RTX 50 series quick start
+docker pull modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.8:v1.0.0
+
+docker tag modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.8:v1.0.0 cpmcu:cuda12.8-release
+
+docker run --gpus all -it cpmcu:cuda12.8-release /bin/bash
 ```
 
 ### Offline Usage (Recommended)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -75,6 +75,8 @@ pip install .
 
 ### 快速开始
 
+如果你使用的是 RTX 50 系显卡，建议优先使用下面的 CUDA 12.8 镜像。仓库现有 Docker 文档已经将 CUDA 12.8 作为 RTX 50 系支持的推荐路径。
+
 ```bash
 # 拉取预构建镜像
 docker pull modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.6:v1.0.0
@@ -87,6 +89,15 @@ docker run --gpus all -it cpmcu:cuda12.6-release /bin/bash
 # 启动 API 服务器(需要登录 huggingface 或 -v 挂载模型)
 docker run --gpus all -p 8000:8000 cpmcu:cuda12.6-release \
   python examples/minicpm4/start_server.py --apply-sparse 
+```
+
+```bash
+# RTX 50 系快速开始
+docker pull modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.8:v1.0.0
+
+docker tag modelbest-registry.cn-beijing.cr.aliyuncs.com/model-align/cpmcu_cu12.8:v1.0.0 cpmcu:cuda12.8-release
+
+docker run --gpus all -it cpmcu:cuda12.8-release /bin/bash
 ```
 
 ### 离线使用（推荐）


### PR DESCRIPTION
This makes the top-level README surface the existing RTX 50 series Docker guidance earlier.

Failure mechanism:
- doc/en/docker_use.md and doc/en/docker_build.md already point RTX 50 users to CUDA 12.8
- the top-level README quick start still centered the CUDA 12.6 image with no explicit RTX 50 fast path
- that makes first-run setup easy to choose incorrectly on Blackwell consumer GPUs

Semantic change:
- add an explicit RTX 50 / CUDA 12.8 recommendation before the Docker quick start block
- add matching 12.8 quick-start commands in both README.md and README_ZH.md

Preserved invariant:
- existing CUDA 12.6 instructions remain available for the broader GPU set they already target
- no install or runtime behavior changes

Testing:
- compared the new README wording against doc/en/docker_use.md and doc/en/docker_build.md
- mirrored the same guidance in README_ZH.md